### PR TITLE
Fix password escaping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -398,3 +398,6 @@ FodyWeavers.xsd
 *.sln.iml
 
 notes.txt
+
+# IntelliJ IDEA IDE settings
+.idea/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ESE_Companion",
+  "name": "ese_companion",
   "version": "1.0.0",
   "description": "ESE Api and UI for HiveMQ Enterprise Security extension database",
   "main": "index.js",
@@ -28,5 +28,14 @@
   },
   "devDependencies": {
     "nodemon": "^2.0.22"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/guinp1n/ese-companion.git"
+  },
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/guinp1n/ese-companion/issues"
+  },
+  "homepage": "https://github.com/guinp1n/ese-companion#readme"
 }

--- a/src/helpers/cryptoHelper.js
+++ b/src/helpers/cryptoHelper.js
@@ -1,6 +1,7 @@
 const crypto = require('crypto');
 const util = require('util');
 const exec = util.promisify(require('child_process').exec);
+const escape = require('shell-escape');
 
 module.exports = {
   // Below function does not generate same hash than with Java (Bouncy Castle)
@@ -25,7 +26,17 @@ module.exports = {
   },
   generateHash: async function (password, password_salt, password_iterations, algorithm) {
     try {
-      const { stdout, stderr } = await exec("java -jar ./src/helpers/hivemq-ese-helper.jar hash create -a " + algorithm + " -i " + password_iterations + " -p " + password + " -s " + password_salt);
+      //const { stdout, stderr } = await exec("java -jar ./src/helpers/hivemq-ese-helper.jar hash create -a " + algorithm + " -i " + password_iterations + " -p " + password + " -s " + password_salt);
+      const args = escape([
+        'java', '-jar', './src/helpers/hivemq-ese-helper.jar',
+        'hash', 'create',
+        '-a', algorithm,
+        '-i', password_iterations,
+        '-p', password,
+        '-s', password_salt
+      ]);
+
+      const { stdout, stderr } = await exec(args);
       if (stdout) return stdout
       else return stderr
     } catch (e) {


### PR DESCRIPTION
**Fix password handling by adding shell-escape in cryptoHelper.js**

When a user wanted to have a special character in the password, for example `Test(123` had to escape the special character in the password input field like `Test\(123`. Otherwise, they would not be saved to the db correctly.

I fixed it by shell-escape the password in cryptoHelper.js

